### PR TITLE
Add AggregateError supprt

### DIFF
--- a/src/is.ts
+++ b/src/is.ts
@@ -49,6 +49,9 @@ export const isDate = (payload: any): payload is Date =>
 export const isError = (payload: any): payload is Error =>
   payload instanceof Error;
 
+export const isAggregateError = (payload: any): payload is AggregateError =>
+  payload instanceof AggregateError
+
 export const isNaNValue = (payload: any): payload is typeof NaN =>
   typeof payload === 'number' && isNaN(payload);
 

--- a/src/plainer.ts
+++ b/src/plainer.ts
@@ -1,6 +1,7 @@
 import {
   isArray,
   isEmptyObject,
+  isError,
   isMap,
   isPlainObject,
   isPrimitive,
@@ -95,6 +96,7 @@ const isDeep = (object: any, superJson: SuperJSON): boolean =>
   isArray(object) ||
   isMap(object) ||
   isSet(object) ||
+  isError(object) ||
   isInstanceOfRegisteredClass(object, superJson);
 
 function addIdentity(object: any, path: any[], identities: Map<any, any[][]>) {


### PR DESCRIPTION
Relates to #294. Implements support for the relatively new but widely supported [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) type. This is a subclass of Error which supports passing an array of child errors. As an example this is useful if you need to make a series of network requests to load a page, you can return a single error which captures all the related failures.

I figured this would be more controversial than the #296 change so separated the 2. This duplicates some of the changes  but only to provide complete implementation for this MR. I thought it best to introduce it as a separate transformer for backwards compatibility.


Adds type check for AggregateError