### PR TITLE
Export additional types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
-import { Class, JSONValue, SuperJSONResult, SuperJSONValue } from './types.js';
+import {
+  Class,
+  JSONValue,
+  SerializableJSONValue,
+  SuperJSONResult,
+  SuperJSONValue,
+} from './types.js';
 import { ClassRegistry, RegisterOptions } from './class-registry.js';
 import { Registry } from './registry.js';
 import {
@@ -12,6 +18,14 @@ import {
   walker,
 } from './plainer.js';
 import { copy } from 'copy-anything';
+
+export {
+  CustomTransfomer,
+  CustomTransformerRegistry,
+  JSONValue,
+  SerializableJSONValue,
+  SuperJSONValue,
+};
 
 export default class SuperJSON {
   /**


### PR DESCRIPTION
We want to give users the ability to add custom transformers, and for that to work nicely with typescript we need these types. I tried to do `export type` but prettier threw an error (see https://github.com/prettier/prettier-vscode/issues/2558), so I just exported them as values instead. 