### PR TITLE
Export `SuperJSONValue`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,7 @@ export default class SuperJSON {
   );
 }
 
-export { SuperJSON, SuperJSONResult };
+export { SuperJSON, SuperJSONResult, SuperJSONValue };
 
 export const serialize = SuperJSON.serialize;
 export const deserialize = SuperJSON.deserialize;


### PR DESCRIPTION
Without having the type, it's annoying to create generic functions that serialize their input, since the developer has to just reimplement the types, usually by just copy pasting this library's code anyways