### PR TITLE
Add unknown class name to deserialization error

### DIFF
--- a/src/transformer.test.ts
+++ b/src/transformer.test.ts
@@ -1,0 +1,28 @@
+import SuperJSON from './index.js';
+
+import { test, expect } from 'vitest';
+
+test('throws an descriptive error when transforming', () => {
+  const instance = new SuperJSON();
+  class FunnyNumber {
+    constructor(private number: number) {}
+
+    // @ts-ignore
+    get theNumber() {
+      return this.number;
+    }
+  }
+  instance.registerClass(FunnyNumber);
+  expect(() =>
+    instance.deserialize({
+      json: instance.serialize({
+        number: new FunnyNumber(2137),
+      }).json,
+      meta: {
+        values: [['class', 'NotRegistered']],
+      },
+    })
+  ).toThrowError(
+    `Trying to deserialize unknown class 'NotRegistered' - check https://github.com/blitz-js/superjson/issues/116#issuecomment-773996564`
+  );
+});

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -275,7 +275,7 @@ const classRule = compositeTransformation(
 
     if (!clazz) {
       throw new Error(
-        `Trying to deserialize unknown class - ${a[1]} - check https://github.com/blitz-js/superjson/issues/116#issuecomment-773996564`
+        `Trying to deserialize unknown class '${a[1]}' - check https://github.com/blitz-js/superjson/issues/116#issuecomment-773996564`
       );
     }
 

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -275,7 +275,7 @@ const classRule = compositeTransformation(
 
     if (!clazz) {
       throw new Error(
-        'Trying to deserialize unknown class - check https://github.com/blitz-js/superjson/issues/116#issuecomment-773996564'
+        `Trying to deserialize unknown class - ${a[1]} - check https://github.com/blitz-js/superjson/issues/116#issuecomment-773996564`
       );
     }
 


### PR DESCRIPTION
This pull request introduces a new test case and improves error messaging in the `SuperJSON` deserialization process. The changes enhance the developer experience by providing more descriptive error messages and ensuring the robustness of the code.

### Enhancements to error messaging and testing:

* [`src/transformer.ts`](diffhunk://#diff-df7446068188621a3fa66e02d4e5c9081902f1bb2cd9092e06c59271978257d3L278-R278): Updated the error message to include the name of the unknown class being deserialized, making it easier to identify the issue.
* [`src/transformer.test.ts`](diffhunk://#diff-035655380b270a040027fd0c4ca50f1a2f05731e6654bc177d9cd00b1c1e3c5fR1-R28): Added a new test case to verify that an appropriate error is thrown when attempting to deserialize an unregistered class, ensuring that the error message includes missing class name.