### PR TITLE
Add support for Decimal data type

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -523,15 +523,6 @@ describe('stringify & parse', () => {
 
     'works for Decimal.js': {
       input: () => {
-        SuperJSON.registerCustom<Decimal, string>(
-          {
-            isApplicable: (v): v is Decimal => Decimal.isDecimal(v),
-            serialize: v => v.toJSON(),
-            deserialize: v => new Decimal(v),
-          },
-          'decimal.js'
-        );
-
         return {
           a: new Decimal('100.1'),
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import {
   walker,
 } from './plainer.js';
 import { copy } from 'copy-anything';
+import { Decimal } from 'decimal.js';
 
 export default class SuperJSON {
   /**
@@ -28,6 +29,15 @@ export default class SuperJSON {
     dedupe?: boolean;
   } = {}) {
     this.dedupe = dedupe;
+
+    this.registerCustom<Decimal, string>(
+      {
+        isApplicable: (v): v is Decimal => Decimal.isDecimal(v),
+        serialize: v => v.toJSON(),
+        deserialize: v => new Decimal(v),
+      },
+      'decimal.js'
+    );
   }
 
   serialize(object: SuperJSONValue): SuperJSONResult {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -16,6 +16,7 @@ import {
 } from './is.js';
 import { findArr } from './util.js';
 import SuperJSON from './index.js';
+import { Decimal } from 'decimal.js';
 
 export type PrimitiveTypeAnnotation = 'number' | 'undefined' | 'bigint';
 
@@ -308,7 +309,14 @@ const customRule = compositeTransformation(
   }
 );
 
-const compositeRules = [classRule, symbolRule, customRule, typedArrayRule];
+const decimalRule = compositeTransformation(
+  (value): value is Decimal => Decimal.isDecimal(value),
+  () => ['custom', 'decimal.js'],
+  (value) => value.toJSON(),
+  (value) => new Decimal(value)
+);
+
+const compositeRules = [classRule, symbolRule, customRule, typedArrayRule, decimalRule];
 
 export const transformValue = (
   value: any,


### PR DESCRIPTION
Fixes #152

Add support for serialization of Decimal data type.

* **src/transformer.ts**
  - Import the Decimal class from the `decimal.js` library.
  - Add a transformation rule for the Decimal data type.
  - Update the `compositeRules` array to include the new Decimal transformation rule.

* **src/index.ts**
  - Register a custom transformer for the Decimal data type in the `SuperJSON` class constructor.

* **src/index.test.ts**
  - Update the test case for Decimal.js to use the built-in transformer.

