### PR TITLE
fix: input escape mapping

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -779,7 +779,13 @@ describe('stringify & parse', () => {
       } else {
         expect(json).toEqual(expectedOutput);
       }
-      expect(meta).toEqual(expectedOutputAnnotations);
+      if (meta) {
+        const { v, ...rest } = meta;
+        expect(v).toBe(1);
+        expect(rest).toEqual(expectedOutputAnnotations);
+      } else {
+        expect(meta).toEqual(expectedOutputAnnotations);
+      }
 
       const untransformed = SuperJSON.deserialize(
         JSON.parse(JSON.stringify({ json, meta }))
@@ -820,6 +826,7 @@ describe('stringify & parse', () => {
       });
 
       expect(meta).toEqual({
+        v: 1,
         values: {
           s7: [['class', 'Train']],
         },
@@ -883,6 +890,7 @@ describe('stringify & parse', () => {
         a: '1000',
       },
       meta: {
+        v: 1,
         values: {
           a: ['bigint'],
         },
@@ -966,7 +974,7 @@ test('regression #83: negative zero', () => {
 
   const stringified = SuperJSON.stringify(input);
   expect(stringified).toMatchInlineSnapshot(
-    `"{\\"json\\":\\"-0\\",\\"meta\\":{\\"values\\":[\\"number\\"]}}"`
+    `"{\\"json\\":\\"-0\\",\\"meta\\":{\\"values\\":[\\"number\\"],\\"v\\":1}}"`
   );
 
   const parsed: number = SuperJSON.parse(stringified);
@@ -1186,6 +1194,7 @@ test('regression #245: superjson referential equalities only use the top-most pa
           "b",
         ],
       },
+      "v": 1,
     }
   `);
 
@@ -1260,4 +1269,44 @@ test('doesnt iterate to keys that dont exist', () => {
   res.meta.referentialEqualities.topScorer = ['highscores.99999.0'];
 
   expect(() => SuperJSON.deserialize(res)).toThrowError('index out of bounds');
+});
+
+test('#310 fixes backwards compat', () => {
+  expect(
+    SuperJSON.deserialize({
+      json: {
+        'a\\.1': {
+          b: [1, 2],
+        },
+      },
+      meta: {
+        values: {
+          'a\\\\.1.b': ['set'],
+        },
+      },
+    })
+  ).toEqual({
+    'a\\.1': {
+      b: new Set([1, 2]),
+    },
+  });
+
+  expect(
+    SuperJSON.deserialize({
+      json: {
+        'a.1': {
+          b: [1, 2],
+        },
+      },
+      meta: {
+        values: {
+          'a\\.1.b': ['set'],
+        },
+      },
+    })
+  ).toEqual({
+    'a.1': {
+      b: new Set([1, 2]),
+    },
+  });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -174,7 +174,7 @@ describe('stringify & parse', () => {
       },
       outputAnnotations: {
         values: {
-          'a\\\\.1.b': ['set'],
+          'a\\\\\\.1.b': ['set'],
         },
       },
     },
@@ -683,6 +683,26 @@ describe('stringify & parse', () => {
         values: {
           a: ['URL'],
           b: ['URL'],
+        },
+      },
+    },
+    'repro #310: meta path escape bug': {
+      input: {
+        a: ["/'a'[0]: string that becomes a regex/"],
+        'a.0': /'a.0': regex that becomes a string/,
+        'b.0': "/'b.0': string that becomes a regex/",
+        'b\\': [/'b\\'[0]: regex that becomes a string/],
+      },
+      output: {
+        a: ["/'a'[0]: string that becomes a regex/"],
+        'a.0': "/'a.0': regex that becomes a string/",
+        'b.0': "/'b.0': string that becomes a regex/",
+        'b\\': ["/'b\\\\'[0]: regex that becomes a string/"],
+      },
+      outputAnnotations: {
+        values: {
+          'a\\.0': ['regexp'],
+          'b\\\\.0': ['regexp'],
         },
       },
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,8 @@ export default class SuperJSON {
       };
     }
 
+    if (res.meta) res.meta.v = 1;
+
     return res;
   }
 
@@ -64,13 +66,14 @@ export default class SuperJSON {
     let result: T = copy(json) as any;
 
     if (meta?.values) {
-      result = applyValueAnnotations(result, meta.values, this);
+      result = applyValueAnnotations(result, meta.values, meta.v ?? 0, this);
     }
 
     if (meta?.referentialEqualities) {
       result = applyReferentialEqualityAnnotations(
         result,
-        meta.referentialEqualities
+        meta.referentialEqualities,
+        meta.v ?? 0
       );
     }
 

--- a/src/pathstringifier.test.ts
+++ b/src/pathstringifier.test.ts
@@ -6,9 +6,9 @@ describe('parsePath', () => {
   it.each([
     ['test.a.b', ['test', 'a', 'b']],
     ['test\\.a.b', ['test.a', 'b']],
-    ['test\\\\.a.b', ['test\\.a', 'b']],
+    ['test\\\\.a.b', ['test\\', 'a', 'b']],
     ['test\\a.b', ['test\\a', 'b']],
-    ['test\\\\a.b', ['test\\\\a', 'b']],
+    ['test\\\\a.b', ['test\\a', 'b']],
   ])('parsePath(%p) === %p', (input, expectedOutput) => {
     expect(parsePath(input)).toEqual(expectedOutput);
   });

--- a/src/pathstringifier.test.ts
+++ b/src/pathstringifier.test.ts
@@ -6,11 +6,27 @@ describe('parsePath', () => {
   it.each([
     ['test.a.b', ['test', 'a', 'b']],
     ['test\\.a.b', ['test.a', 'b']],
-    ['test\\\\.a.b', ['test\\', 'a', 'b']],
+    ['test\\\\.a.b', ['test\\.a', 'b']],
     ['test\\a.b', ['test\\a', 'b']],
+    ['test\\\\a.b', ['test\\\\a', 'b']],
+  ])('legacy parsePath(%p) === %p', (input, expectedOutput) => {
+    expect(parsePath(input, true)).toEqual(expectedOutput);
+  });
+
+  it.each([
+    ['test.a.b', ['test', 'a', 'b']],
+    ['test\\.a.b', ['test.a', 'b']],
+    ['test\\\\.a.b', ['test\\', 'a', 'b']],
     ['test\\\\a.b', ['test\\a', 'b']],
   ])('parsePath(%p) === %p', (input, expectedOutput) => {
-    expect(parsePath(input)).toEqual(expectedOutput);
+    expect(parsePath(input, false)).toEqual(expectedOutput);
+  });
+
+  it.each([
+    'test\\a.b',
+    'foo.bar.baz\\',
+  ])('parsePath(%p) is rejected', (input) => {
+    expect(() => parsePath(input, false)).toThrowError();
   });
 });
 

--- a/src/pathstringifier.ts
+++ b/src/pathstringifier.ts
@@ -10,18 +10,20 @@ export const stringifyPath = (path: Path): StringifiedPath =>
     .map(escapeKey)
     .join('.');
 
-export const parsePath = (string: StringifiedPath) => {
+export const parsePath = (string: StringifiedPath, legacyPaths: boolean) => {
   const result: string[] = [];
 
   let segment = '';
   for (let i = 0; i < string.length; i++) {
     let char = string.charAt(i);
 
-    const isEscapedBackslash = char === '\\' && string.charAt(i + 1) === '\\';
-    if (isEscapedBackslash) {
-      segment += '\\';
-      i++;
-      continue;
+    if (!legacyPaths) {
+      const isEscapedBackslash = char === '\\' && string.charAt(i + 1) === '\\';
+      if (isEscapedBackslash) {
+        segment += '\\';
+        i++;
+        continue;
+      }
     }
 
     const isEscapedDot = char === '\\' && string.charAt(i + 1) === '.';

--- a/src/pathstringifier.ts
+++ b/src/pathstringifier.ts
@@ -17,12 +17,14 @@ export const parsePath = (string: StringifiedPath, legacyPaths: boolean) => {
   for (let i = 0; i < string.length; i++) {
     let char = string.charAt(i);
 
-    if (!legacyPaths) {
-      const isEscapedBackslash = char === '\\' && string.charAt(i + 1) === '\\';
-      if (isEscapedBackslash) {
+    if (!legacyPaths && char === '\\') {
+      const escaped = string.charAt(i + 1);
+      if (escaped === '\\') {
         segment += '\\';
         i++;
         continue;
+      } else if (escaped !== '.') {
+        throw Error('invalid path');
       }
     }
 

--- a/src/pathstringifier.ts
+++ b/src/pathstringifier.ts
@@ -1,7 +1,8 @@
 export type StringifiedPath = string;
 type Path = string[];
 
-export const escapeKey = (key: string) => key.replace(/\./g, '\\.');
+export const escapeKey = (key: string) =>
+  key.replace(/\\/g, '\\\\').replace(/\./g, '\\.');
 
 export const stringifyPath = (path: Path): StringifiedPath =>
   path
@@ -15,6 +16,13 @@ export const parsePath = (string: StringifiedPath) => {
   let segment = '';
   for (let i = 0; i < string.length; i++) {
     let char = string.charAt(i);
+
+    const isEscapedBackslash = char === '\\' && string.charAt(i + 1) === '\\';
+    if (isEscapedBackslash) {
+      segment += '\\';
+      i++;
+      continue;
+    }
 
     const isEscapedDot = char === '\\' && string.charAt(i + 1) === '.';
     if (isEscapedDot) {

--- a/src/plainer.ts
+++ b/src/plainer.ts
@@ -24,18 +24,25 @@ type InnerNode<T> = [T, Record<string, Tree<T>>];
 
 export type MinimisedTree<T> = Tree<T> | Record<string, Tree<T>> | undefined;
 
+const enableLegacyPaths = (version: number) => version < 1;
+
 function traverse<T>(
   tree: MinimisedTree<T>,
   walker: (v: T, path: string[]) => void,
+  version: number,
   origin: string[] = []
 ): void {
   if (!tree) {
     return;
   }
 
+  const legacyPaths = enableLegacyPaths(version);
   if (!isArray(tree)) {
     forEach(tree, (subtree, key) =>
-      traverse(subtree, walker, [...origin, ...parsePath(key)])
+      traverse(subtree, walker, version, [
+        ...origin,
+        ...parsePath(key, legacyPaths),
+      ])
     );
     return;
   }
@@ -43,7 +50,10 @@ function traverse<T>(
   const [nodeValue, children] = tree;
   if (children) {
     forEach(children, (child, key) => {
-      traverse(child, walker, [...origin, ...parsePath(key)]);
+      traverse(child, walker, version, [
+        ...origin,
+        ...parsePath(key, legacyPaths),
+      ]);
     });
   }
 
@@ -53,31 +63,44 @@ function traverse<T>(
 export function applyValueAnnotations(
   plain: any,
   annotations: MinimisedTree<TypeAnnotation>,
+  version: number,
   superJson: SuperJSON
 ) {
-  traverse(annotations, (type, path) => {
-    plain = setDeep(plain, path, v => untransformValue(v, type, superJson));
-  });
+  traverse(
+    annotations,
+    (type, path) => {
+      plain = setDeep(plain, path, v => untransformValue(v, type, superJson));
+    },
+    version
+  );
 
   return plain;
 }
 
 export function applyReferentialEqualityAnnotations(
   plain: any,
-  annotations: ReferentialEqualityAnnotations
+  annotations: ReferentialEqualityAnnotations,
+  version: number
 ) {
+  const legacyPaths = enableLegacyPaths(version);
   function apply(identicalPaths: string[], path: string) {
-    const object = getDeep(plain, parsePath(path));
+    const object = getDeep(plain, parsePath(path, legacyPaths));
 
-    identicalPaths.map(parsePath).forEach(identicalObjectPath => {
-      plain = setDeep(plain, identicalObjectPath, () => object);
-    });
+    identicalPaths
+      .map(path => parsePath(path, legacyPaths))
+      .forEach(identicalObjectPath => {
+        plain = setDeep(plain, identicalObjectPath, () => object);
+      });
   }
 
   if (isArray(annotations)) {
     const [root, other] = annotations;
     root.forEach(identicalPath => {
-      plain = setDeep(plain, parsePath(identicalPath), () => plain);
+      plain = setDeep(
+        plain,
+        parsePath(identicalPath, legacyPaths),
+        () => plain
+      );
     });
 
     if (other) {

--- a/src/plainer.ts
+++ b/src/plainer.ts
@@ -239,7 +239,7 @@ export const walker = (
     transformedValue[index] = recursiveResult.transformedValue;
 
     if (isArray(recursiveResult.annotations)) {
-      innerAnnotations[index] = recursiveResult.annotations;
+      innerAnnotations[escapeKey(index)] = recursiveResult.annotations;
     } else if (isPlainObject(recursiveResult.annotations)) {
       forEach(recursiveResult.annotations, (tree, key) => {
         innerAnnotations[escapeKey(index) + '.' + key] = tree;

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,5 +42,6 @@ export interface SuperJSONResult {
   meta?: {
     values?: MinimisedTree<TypeAnnotation>;
     referentialEqualities?: ReferentialEqualityAnnotations;
+    v?: number;
   };
 }


### PR DESCRIPTION
Closes https://github.com/flightcontrolhq/superjson/issues/310

There's a bug in the path escaping logic where meta was applied to the wrong values. This PR fixes the escape bug. It also introduces a version tag to toggle the path escaping when deserializing. This ensures backwards compatibility for SuperJSON results that were created on a version with the bug.