### PR TITLE
Use `symbol` instead of `Symbol`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,7 @@ export interface JSONObject {
 type ClassInstance = any;
 
 export type SerializableJSONValue =
-  | Symbol
+  | symbol
   | Set<SuperJSONValue>
   | Map<SuperJSONValue, SuperJSONValue>
   | undefined


### PR DESCRIPTION
[As the TypeScript Handbook says:](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#number-string-boolean-symbol-and-object)

> Don’t ever use the types `Number`, `String`, `Boolean`, `Symbol`, or `Object` These types refer to non-primitive boxed objects that are almost never used appropriately in JavaScript code.
> Do use the types `number`, `string`, `boolean`, and `symbol`.

Unless there is a specific reason to use `Symbol`, we should probably use `symbol`. Just checking because we are copying these types into our app, and flagged this in our review: https://github.com/wasp-lang/wasp/pull/2672#discussion_r2046520097