### PR TITLE
fix: in tsconfig, set moduleResolution to node16

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ES6",
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "lib": ["esnext"],
     "importHelpers": false,
     "declaration": true,
@@ -17,6 +17,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
-    "downlevelIteration": true
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
Previously, the build was failing due to module resolution issues with the `copy-anything` dependency and .js file extensions in imports. Using the more modern node16 module resolution approach solves this.

I've also removed `downlevelIteration` (no effect when targeting ES2020) and added `skipLibCheck` (avoids throwing type errors due to inconsistencies within dependencies).
