### PR TITLE
perf: require Node.js 20+, Safari 14+

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,19 +1,5 @@
 module.exports = {
-  plugins: ['es5'],
   rules: {
-    'es5/no-for-of': 'error',
-    'es5/no-generators': 'error',
-    'es5/no-typeof-symbol': 'error',
-    'es5/no-es6-methods': 'error',
-    'es5/no-es6-static-methods': [
-      'error',
-      {
-        exceptMethods: ['Object.assign'],
-      },
-    ],
-    "no-restricted-syntax": [
-      "error",
-      "ForInStatement"
-    ]
+    // No ESLint rules yet
   },
 };

--- a/package.json
+++ b/package.json
@@ -5,15 +5,15 @@
   "typings": "dist/index.d.ts",
   "main": "./dist/index.js",
   "exports": {
-      "import": "./dist/index.js",
-      "require": "./dist-cjs/index.cjs"
+    "import": "./dist/index.js",
+    "require": "./dist-cjs/index.cjs"
   },
   "files": [
     "dist",
     "dist-cjs"
   ],
   "engines": {
-    "node": ">=16"
+    "node": ">=20"
   },
   "scripts": {
     "build": "yarn run build:esm && yarn run build:cjs",
@@ -72,9 +72,6 @@
     "tsdx": "^0.14.1",
     "typescript": "^4.2.4",
     "vitest": "^0.34.6"
-  },
-  "dependencies": {
-    "copy-anything": "^4"
   },
   "resolutions": {
     "**/@typescript-eslint/eslint-plugin": "^4.11.1",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable es5/no-for-of */
-/* eslint-disable es5/no-es6-methods */
-
 import * as fs from 'fs';
 
 import SuperJSON from './index.js';
@@ -875,43 +872,10 @@ describe('stringify & parse', () => {
     it.todo('has undefined behaviour');
   });
 
-  test('regression #65: BigInt on Safari v13', () => {
-    const oldBigInt = global.BigInt;
-    // @ts-ignore
-    delete global.BigInt;
-
-    const input = {
-      a: oldBigInt('1000'),
-    };
-
-    const superJSONed = SuperJSON.serialize(input);
-    expect(superJSONed).toEqual({
-      json: {
-        a: '1000',
-      },
-      meta: {
-        v: 1,
-        values: {
-          a: ['bigint'],
-        },
-      },
-    });
-
-    const deserialised = SuperJSON.deserialize(
-      JSON.parse(JSON.stringify(superJSONed))
-    );
-    expect(deserialised).toEqual({
-      a: '1000',
-    });
-
-    global.BigInt = oldBigInt;
-  });
-
   test('regression #80: Custom error serialisation isnt overriden', () => {
     class CustomError extends Error {
       constructor(public readonly customProperty: number) {
         super("I'm a custom error");
-        // eslint-disable-next-line es5/no-es6-static-methods
         Object.setPrototypeOf(this, CustomError.prototype);
       }
     }
@@ -1275,7 +1239,9 @@ test('doesnt iterate to keys that dont exist', () => {
 test('deserialize in place', () => {
   const serialized = SuperJSON.serialize({ a: new Date() });
   const deserializedCopy = SuperJSON.deserialize(serialized);
-  const deserializedInPlace = SuperJSON.deserialize(serialized, { inPlace: true });
+  const deserializedInPlace = SuperJSON.deserialize(serialized, {
+    inPlace: true,
+  });
   expect(deserializedInPlace).toBe(serialized.json);
   expect(deserializedCopy).not.toBe(serialized.json);
   expect(deserializedCopy).toEqual(deserializedInPlace);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,6 @@ import {
   generateReferentialEqualityAnnotations,
   walker,
 } from './plainer.js';
-import { copy } from 'copy-anything';
 
 export default class SuperJSON {
   /**
@@ -60,10 +59,13 @@ export default class SuperJSON {
     return res;
   }
 
-  deserialize<T = unknown>(payload: SuperJSONResult, options?: { inPlace?: boolean }): T {
+  deserialize<T = unknown>(
+    payload: SuperJSONResult,
+    options?: { inPlace?: boolean }
+  ): T {
     const { json, meta } = payload;
 
-    let result: T = options?.inPlace ? json : copy(json) as any;
+    let result: T = options?.inPlace ? json : (structuredClone(json) as any);
 
     if (meta?.values) {
       result = applyValueAnnotations(result, meta.values, meta.v ?? 0, this);

--- a/src/is.test.ts
+++ b/src/is.test.ts
@@ -36,7 +36,6 @@ test('Basic true tests', () => {
   expect(isTypedArray(new Uint8Array())).toBe(true);
   expect(isURL(new URL('https://example.com'))).toBe(true);
   expect(isPlainObject({})).toBe(true);
-  // eslint-disable-next-line no-new-object
   expect(isPlainObject(new Object())).toBe(true);
 });
 
@@ -78,7 +77,6 @@ test('Primitive tests', () => {
   expect(isPrimitive([])).toBe(false);
   expect(isPrimitive([])).toBe(false);
   expect(isPrimitive({})).toBe(false);
-  // eslint-disable-next-line no-new-object
   expect(isPrimitive(new Object())).toBe(false);
   expect(isPrimitive(new Date())).toBe(false);
   expect(isPrimitive(() => {})).toBe(false);

--- a/src/pathstringifier.test.ts
+++ b/src/pathstringifier.test.ts
@@ -22,12 +22,12 @@ describe('parsePath', () => {
     expect(parsePath(input, false)).toEqual(expectedOutput);
   });
 
-  it.each([
-    'test\\a.b',
-    'foo.bar.baz\\',
-  ])('parsePath(%p) is rejected', (input) => {
-    expect(() => parsePath(input, false)).toThrowError();
-  });
+  it.each(['test\\a.b', 'foo.bar.baz\\'])(
+    'parsePath(%p) is rejected',
+    input => {
+      expect(() => parsePath(input, false)).toThrowError();
+    }
+  );
 });
 
 describe('escapeKey', () => {

--- a/src/transformer.ts
+++ b/src/transformer.ts
@@ -66,15 +66,7 @@ const simpleRules = [
     isBigint,
     'bigint',
     v => v.toString(),
-    v => {
-      if (typeof BigInt !== 'undefined') {
-        return BigInt(v);
-      }
-
-      console.error('Please add a BigInt polyfill.');
-
-      return v as any;
-    }
+    v => BigInt(v)
   ),
   simpleTransformation(
     isDate,
@@ -125,8 +117,6 @@ const simpleRules = [
   simpleTransformation(
     isSet,
     'set',
-    // (sets only exist in es6+)
-    // eslint-disable-next-line es5/no-es6-methods
     v => [...v.values()],
     v => new Set(v)
   ),

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,41 +1,8 @@
-function valuesOfObj<T>(record: Record<string, T>): T[] {
-  if ('values' in Object) {
-    // eslint-disable-next-line es5/no-es6-methods
-    return Object.values(record);
-  }
-
-  const values: T[] = [];
-
-  // eslint-disable-next-line no-restricted-syntax
-  for (const key in record) {
-    if (record.hasOwnProperty(key)) {
-      values.push(record[key]);
-    }
-  }
-
-  return values;
-}
-
 export function find<T>(
   record: Record<string, T>,
   predicate: (v: T) => boolean
 ): T | undefined {
-  const values = valuesOfObj(record);
-  if ('find' in values) {
-    // eslint-disable-next-line es5/no-es6-methods
-    return values.find(predicate);
-  }
-
-  const valuesNotNever = values as T[];
-
-  for (let i = 0; i < valuesNotNever.length; i++) {
-    const value = valuesNotNever[i];
-    if (predicate(value)) {
-      return value;
-    }
-  }
-
-  return undefined;
+  return Object.values(record).find(predicate);
 }
 
 export function forEach<T>(
@@ -46,19 +13,12 @@ export function forEach<T>(
 }
 
 export function includes<T>(arr: T[], value: T) {
-  return arr.indexOf(value) !== -1;
+  return arr.includes(value);
 }
 
 export function findArr<T>(
   record: T[],
   predicate: (v: T) => boolean
 ): T | undefined {
-  for (let i = 0; i < record.length; i++) {
-    const value = record[i];
-    if (predicate(value)) {
-      return value;
-    }
-  }
-
-  return undefined;
+  return record.find(predicate);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "target": "ES2020",
     "module": "ES6",
     "moduleResolution": "node",
-    "lib": ["esnext"],
+    "lib": ["ES2020"],
     "importHelpers": false,
     "declaration": true,
     "sourceMap": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2592,13 +2592,6 @@ convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
-copy-anything@^4:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/copy-anything/-/copy-anything-4.0.5.tgz#16cabafd1ea4bb327a540b750f2b4df522825aea"
-  integrity sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==
-  dependencies:
-    is-what "^5.2.0"
-
 copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz"
@@ -4125,11 +4118,6 @@ is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
-
-is-what@^5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/is-what/-/is-what-5.2.1.tgz#f8c23952fa1047386784d2ea6d548860bf027642"
-  integrity sha512-FLNNgur29o+0/G6RcG3B6KRDCT6SvMfb7MlfjdydTZWPgBLfiemceChDhY0DHu50O35BDNbNp4rJLQXMt4fG0g==
 
 is-windows@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
**This change requires a major version bump.**

This PR makes some backward compatibility-breaking changes to improve performance:

1. Using `structuredClone` (available in Node.js 18+) instead of the `copy-anything` dependency.
2. Assuming `BigInt` (available in Safari 14+ and every other runtime from 2021 onward) always exists.

It also drops the ESLint rules that forbade various ES6 features. The only reason not to use ES6 was IE11, which Microsoft officially ended support for in 2022.

Since Node.js 18 reached its EOL date in April 2025, I've bumped the `engines` declaration to `"node": ">=20"`. None of the changes here require Node.js 20, but I think it's a good idea to make that bump in case we want to take advantage of Node.js 20-specific features in the future.
